### PR TITLE
Add slight right-margin to latest logs images

### DIFF
--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -431,7 +431,7 @@
 
             // First entry is undefined, due to ajax
             if(logType) {
-	            latestLogs.push('<img src="' + logType + '" style="margin-bottom: -4px;">');
+	            latestLogs.push('<img src="' + logType + '" style="margin-bottom: -4px; margin-right: 1px;">');
 
 	            // 2 = found, 3 = dnf, 4 = note, 5 = archive, 22 = disable, 24 = publish, 45 = nm, 46 = owner maintenance, 68 = reviewer note
 	            var logTypeId = logType.replace(/.*logtypes\/(.*)\.png/, "$1");


### PR DESCRIPTION
If you look at http://coord.info/GC5NJ2B for instance, you will see that the Latest logs icons blend together, because the Will Attend icons have no whitespace around them.

Giving them a 1 pixel margin on the right seperates them visually.

Before:
![latestbefore](https://cloud.githubusercontent.com/assets/5115488/7534483/3dd156d4-f57b-11e4-96a6-5d35b14df9f8.png)

After:
![latestafter](https://cloud.githubusercontent.com/assets/5115488/7534486/439c85fc-f57b-11e4-82c7-5b38e7d8c674.png)
