### PR TITLE
Fix geocoding placement

### DIFF
--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -475,7 +475,7 @@
                         return false;
                     }
                     var formattedAddress = result.results[0].formatted_address;
-                    $('#ctl00_ContentBody_LocationSubPanel').html(formattedAddress + '<br />');
+                    $('#ctl00_ContentBody_LocationSubPanel').append(formattedAddress + '<br />');
                 }
             });
         }


### PR DESCRIPTION
Currently the formatted address will always overwrite the UTM coordinates. 

It should be appending instead of replacing.