### PR TITLE
Fix UTM removal

### DIFF
--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -437,7 +437,7 @@
         // Remove the UTM coordinates
         // $('#ctl00_ContentBody_CacheInformationTable div.LocationData div.span-9 p.NoBottomSpacing br').remove();
         if(IsSettingEnabled('removeUTM')) {
-            $('#ctl00_ContentBody_LocationSubPanel').html();
+            $('#ctl00_ContentBody_LocationSubPanel').html('');
         }
 
 


### PR DESCRIPTION
Currently this doesn't work. Calling html() without an argument doesn't set it, it only retrieves it. Making this a no-op.

Due to the issue described in #7 this wasn't noticed before, as that issue would result in the removal of the UTM coordinates as well.

With the introduction of the settings pane, you can switch off the geocoding while having UTM removal switched on, making this bug manifest itself.