### PR TITLE
Fix mamsl adding on EarthCaches

### DIFF
--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -357,7 +357,7 @@
 				        // Add elevation
 				        if(IsSettingEnabled('addElevation')) {
 				        	// Metres above mean sea level = mamsl
-				        	$('#uxLatLonLink').after('<span> (' + cacheData['elevation'] + ' mamsl)</span>');
+				        	($('#uxLatLonLink').length > 0 ? $('#uxLatLonLink') : $('#uxLatLon').parent()).after('<span> (' + cacheData['elevation'] + ' mamsl)</span>');
 				        }
 
 


### PR DESCRIPTION
Not all cache types have the option to edit it's coordinates, so not all cache pages have an #uxLatLonLink. See http://coord.info/GC2BX63 for an example.

This fix falls back to using #uxLatLon if #uxLatLonLink isn't present.

Before:
![mamslbefore](https://cloud.githubusercontent.com/assets/5115488/7547574/913ad37a-f5f0-11e4-9914-eea85eac1222.png)

After:
![mamslafter](https://cloud.githubusercontent.com/assets/5115488/7547575/959feca2-f5f0-11e4-9c72-c65fb9396040.png)
