### PR TITLE
Add famsl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-greasemonkey-geocaching-projectgc
+﻿greasemonkey-geocaching-projectgc
 =================================
 
 Adds links and data to Geocaching.com to make it collaborate with Project-GC.com.
@@ -31,7 +31,7 @@ Existing features:
 * Add links to plot bookmark lists on maps, from geocache pages.
 * Add links to Profile stats for bookmark list owners, from geocache pages.
 * Autodecrypt hints.
-* Add metres above mean sea level.
+* Add metres/feet above mean sea level.
 
 Planned features:
 * If unread message exists at Project-GC.com, show so at Geocaching.com.

--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -75,7 +75,8 @@
             addPgcGalleryLinks: { title: 'Add links to PGC gallery', default: true },
             addMapBookmarkListLinks: { title: 'Add links for bookmark lists', default: true },
             decryptHints: { title: 'Automatically decrypt hints', default: true },
-            addElevation: { title: 'Add elevation', default: true }
+            addElevation: { title: 'Add elevation', default: true },
+            imperial: { title: 'Use imperial units', default: false }
             };
         return items;
     }
@@ -115,6 +116,19 @@
 
     function IsSettingEnabled(setting) {
     	return settings[setting];
+    }
+
+
+    function MetersToFeet(meters) {
+    	return Math.round(meters * 3.28084);
+    }
+
+    function FormatDistance(distance) {
+        distance = parseInt(distance, 10);
+        distance = IsSettingEnabled('imperial') ? MetersToFeet(distance) : distance;
+        distance = distance.toLocaleString();
+        
+        return distance;
     }
 
 
@@ -328,7 +342,8 @@
                         location = [],
                         fp = 0,
                         fpp = 0,
-                        fpw = 0;
+                        fpw = 0,
+                        elevation = '';
 
 
                     if(result.status == 'OK' && cacheData !== false) {
@@ -355,12 +370,13 @@
                         }
 
 
-				        // Add elevation
-				        if(IsSettingEnabled('addElevation')) {
-				        	// Metres above mean sea level = mamsl
-				        	($('#uxLatLonLink').length > 0 ? $('#uxLatLonLink') : $('#uxLatLon').parent()).after('<span> (' + cacheData['elevation'] + ' mamsl)</span>');
-				        }
+                        // Add elevation (Metres above mean sea level = mamsl)
+                        if(IsSettingEnabled('addElevation')) {
+                            elevation = FormatDistance(cacheData['elevation']);
+                            elevation += IsSettingEnabled('imperial') ? ' famsl' : ' mamsl';
 
+                            ($('#uxLatLonLink').length > 0 ? $('#uxLatLonLink') : $('#uxLatLon').parent()).after('<span> (' + elevation + ')</span>');
+                        }
 
                         // Add PGC location
                         if(IsSettingEnabled('addPGCLocation')) {


### PR DESCRIPTION
Elevation above mean sea level can be expressed in both meters or feet (mamsl or famsl).

This change introduces a "Use imperial units" setting which can be used throughout the script to determine if distances should be shown as metric or as imperial.

This setting is then used to show the elevation either in mamsl or famsl.

I also tweaked how the number is formatted. It now respects the display rules of the current locale (i.e.  28,891 instead of 28891), which improves readability.