### PR TITLE
Set z-index to force map zoom controls behind the settings menu

### DIFF
--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -173,7 +173,7 @@
                 <button id="pgcUserMenuButton" type="button" class="li-user-toggle" onclick="$(\'#pgcUserMenu\').toggle();">\
                     <svg version="1.1" viewBox="0 0 13 8" height="8px" width="13px" xmlns="http://www.w3.org/2000/svg"><title>Open Menu</title><g fill-rule="evenodd" fill="none" stroke-width="1" stroke="none"><g transform="translate(-1277.000000, -25.000000)" class="arrow" stroke="#FFFFFF" fill="#FFFFFF"><path transform="translate(1283.254319, 28.582435) scale(1, -1) rotate(-90.000000) translate(-1283.254319, -28.582435) " d="M1280.43401 23.3387013C1280.20315 23.5702719 1280.20315 23.945803 1280.43401 24.1775793L1284.82138 28.5825631 1280.43401 32.9873411C1280.20315 33.2191175 1280.20315 33.5944429 1280.43401 33.8262192 1280.54934 33.9420045 1280.70072 34 1280.8519 34 1281.00307 34 1281.15425 33.9422102 1281.26978 33.8262192L1286.07462 29.0018993C1286.30548 28.7701229 1286.30548 28.3947975 1286.07462 28.1630212L1281.26958 23.3387013C1281.03872 23.106925 1280.66487 23.106925 1280.43401 23.3387013Z"/></g></g></svg>\
                 </button>\
-                <ul id="pgcUserMenu">\
+                <ul id="pgcUserMenu" style="z-index: 1005;">\
                     <form id="pgcUserMenuForm" style="color: #5f452a;">';
 
                 var items = GetSettingsItems();


### PR DESCRIPTION
This fixes the issue depicted in the image:

![mapzoom](https://cloud.githubusercontent.com/assets/5115488/7550120/a492be28-f655-11e4-8e56-bc73daae71cd.png)
