### PR TITLE
Hide settings menu when clicking outside of it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-greasemonkey-geocaching-projectgc
+﻿greasemonkey-geocaching-projectgc
 =================================
 
 Adds links and data to Geocaching.com to make it collaborate with Project-GC.com.
@@ -39,7 +39,6 @@ Planned features:
 
 Known issues:
 * Project-GC settings dialog should use the user-expanded class if possible.
-* Project-GC settings dialog should close when clicking outside of it (when that works, remove the cancel button).
 * Project-GC settings button doesn't show the arrow properly.
 * Project-GC settings form doesn't have the correct css on https://www.geocaching.com/account/settings/profile .
 * Project-GC settings form should be more organized.

--- a/greasemonkey-geocaching-projectgc.user.js
+++ b/greasemonkey-geocaching-projectgc.user.js
@@ -161,6 +161,7 @@
                 }
 
                 var html = '\
+                <div onclick="$(\'#pgcUserMenu, #pgcSettingsOverlay\').toggle();" style="position: fixed; top: 0; bottom: 0; left: 0; right: 0; z-index:1004; display: none;" id="pgcSettingsOverlay"></div>\
                 <a class="SignedInProfileLink" href="' + pgcUrl + 'ProfileStats/' + pgcUsername + '" title="Project-GC">\
                     <span class="avatar">\
                         <img src="http://project-gc.com/favicon.ico" alt="Logo" width="30" height="30" style="border-radius:100%; border-width:0px;">\
@@ -170,7 +171,7 @@
                         <span class="cache-count">' + subscriptionContent + '</span>\
                     </span>\
                 </a>\
-                <button id="pgcUserMenuButton" type="button" class="li-user-toggle" onclick="$(\'#pgcUserMenu\').toggle();">\
+                <button id="pgcUserMenuButton" type="button" class="li-user-toggle" onclick="$(\'#pgcUserMenu, #pgcSettingsOverlay\').toggle();">\
                     <svg version="1.1" viewBox="0 0 13 8" height="8px" width="13px" xmlns="http://www.w3.org/2000/svg"><title>Open Menu</title><g fill-rule="evenodd" fill="none" stroke-width="1" stroke="none"><g transform="translate(-1277.000000, -25.000000)" class="arrow" stroke="#FFFFFF" fill="#FFFFFF"><path transform="translate(1283.254319, 28.582435) scale(1, -1) rotate(-90.000000) translate(-1283.254319, -28.582435) " d="M1280.43401 23.3387013C1280.20315 23.5702719 1280.20315 23.945803 1280.43401 24.1775793L1284.82138 28.5825631 1280.43401 32.9873411C1280.20315 33.2191175 1280.20315 33.5944429 1280.43401 33.8262192 1280.54934 33.9420045 1280.70072 34 1280.8519 34 1281.00307 34 1281.15425 33.9422102 1281.26978 33.8262192L1286.07462 29.0018993C1286.30548 28.7701229 1286.30548 28.3947975 1286.07462 28.1630212L1281.26958 23.3387013C1281.03872 23.106925 1280.66487 23.106925 1280.43401 23.3387013Z"/></g></g></svg>\
                 </button>\
                 <ul id="pgcUserMenu">\
@@ -187,8 +188,7 @@
 
                 html += '\
                         <li>\
-                            <button onclick="document.getElementById(\'pgcUserMenuForm\').reset(); $(\'#pgcUserMenu\').hide(); return false;">Cancel</button>\
-                            &nbsp;<button onclick="document.getElementById(\'pgcUserMenuForm\').reset(); return false;">Reset</button>\
+                            <button onclick="document.getElementById(\'pgcUserMenuForm\').reset(); return false;">Reset</button>\
                             &nbsp;<button id="pgcUserMenuSave">Save</button>\
                         </li>\
                         <li id="pgcUserMenuWarning" style="display: none;"><small class="OldWarning">Reload the page to activate the new settings.</small></li>\


### PR DESCRIPTION
When the settings menu is opened, show a page covering transparent div, which when clicked closes the menu. This div is positioned between the menu and the page using a z-index, and therefore this PR is dependent on #18.